### PR TITLE
Remove usage of go-loop for auto-closing the producer

### DIFF
--- a/src/ketu/async/sink.clj
+++ b/src/ketu/async/sink.clj
@@ -156,11 +156,11 @@
                       (finally
                         (log/info logger "[sink={} worker={}] Exit" sink-name %)))
                     (when (zero? (swap! remaining-sender-threads dec))
+                      (log/info logger "[sink={} auto-close] All workers are done" sink-name)
                       (when close-producer?
-                        (log/info logger "[sink={} auto-close] All workers are done" sink-name)
                         (try
                           (close-producer! state)
-                          (catch Throwable e
+                          (catch Exception e
                             (log/error logger "[sink={} auto-close] Error" sink-name e))))
                       (async/close! threads-done-chan))))
                (range sender-threads-num))]

--- a/src/ketu/async/sink.clj
+++ b/src/ketu/async/sink.clj
@@ -67,8 +67,7 @@
         (recur)))))
 
 (defn done-chan [state]
-  (or (:ketu.sink/auto-close-thread state)
-      (:ketu.sink/sender-threads-done state)))
+  (:ketu.sink/sender-threads-done state))
 
 (defn- wait-until-done-or-timeout!
   [state]
@@ -141,35 +140,33 @@
                :ketu.sink/producer producer
                :ketu.sink/abort-input abort-input}
 
-        threads-done-chan        (async/chan)
-        auto-close-chan          (async/chan)
+        threads-done-chan (async/chan)
 
         ;; Channels that are closed when their thread loop is done.
         _ (log/info logger "[sink={}] Start {} worker(s)" sink-name sender-threads-num)
-        sender-threads           (mapv #(let [thread-name (str "ketu-sink-" sink-name "-" %)]
-                                          (async/thread
-                                            (try
-                                              (log/info logger "[sink={} worker={}] Start" sink-name %)
-                                              (.setName (Thread/currentThread) thread-name)
-                                              (send-loop state)
-                                              (catch Throwable e
-                                                (log/error logger "[sink={} worker={}] Unrecoverable error" sink-name % e)))
-                                            (log/info logger "[sink={} worker={}] Exit" sink-name %)
-                                            (when (zero? (swap! remaining-sender-threads dec))
-                                              (async/close! threads-done-chan)
-                                              (when close-producer?
-                                                (log/info logger "[sink={} auto-close] All workers are done" sink-name)
-                                                (try
-                                                  (close-producer! state)
-                                                  (catch Throwable e
-                                                    (log/error logger "[sink={} auto-close] Error" sink-name e))
-                                                  (finally
-                                                    (async/close! auto-close-chan)))))))
-                                       (range sender-threads-num))]
+        sender-threads
+        (mapv #(let [thread-name (str "ketu-sink-" sink-name "-" %)]
+                  (async/thread
+                    (try
+                      (log/info logger "[sink={} worker={}] Start" sink-name %)
+                      (.setName (Thread/currentThread) thread-name)
+                      (send-loop state)
+                      (catch Exception e
+                        (log/error logger "[sink={} worker={}] Unrecoverable error" sink-name % e))
+                      (finally
+                        (log/info logger "[sink={} worker={}] Exit" sink-name %)))
+                    (when (zero? (swap! remaining-sender-threads dec))
+                      (when close-producer?
+                        (log/info logger "[sink={} auto-close] All workers are done" sink-name)
+                        (try
+                          (close-producer! state)
+                          (catch Throwable e
+                            (log/error logger "[sink={} auto-close] Error" sink-name e))))
+                      (async/close! threads-done-chan))))
+               (range sender-threads-num))]
     (-> state
         (assoc :ketu.sink/sender-threads sender-threads
-               :ketu.sink/sender-threads-done threads-done-chan)
-        (cond-> close-producer? (assoc :ketu.sink/auto-close-thread auto-close-chan)))))
+               :ketu.sink/sender-threads-done threads-done-chan))))
 
 (defn sink
   "Sends ProducerRecord's from in-chan to kafka.
@@ -197,6 +194,6 @@
   It shouldn't be necessary to call this function since by default the sink closes
   itself automatically when the input channel is closed."
   [state]
-  (abort-input! state)
   (wait-until-done-or-timeout! state)
+  (abort-input! state)
   (close-producer! state))

--- a/src/ketu/async/util.clj
+++ b/src/ketu/async/util.clj
@@ -1,19 +1,6 @@
 (ns ketu.async.util
-  (:require [clojure.core.async :as async]
-            [clojure.set])
+  (:require [clojure.set])
   (:import (org.apache.kafka.common.serialization Deserializer Serializer)))
-
-(defn blocking-drain! [ch]
-  (loop [] (when (some? (async/<!! ch)) (recur))))
-
-(defn blocking-drain-all! [chs]
-  (blocking-drain! (async/merge chs)))
-
-(defn go-drain! [ch]
-  (async/go-loop [] (when (some? (async/<! ch)) (recur))))
-
-(defn go-drain-all! [chs]
-  (go-drain! (async/merge chs)))
 
 (defn- preset-deserializer-class [value-type]
   (case value-type

--- a/test/ketu/async/integration_test.clj
+++ b/test/ketu/async/integration_test.clj
@@ -120,6 +120,8 @@
       (u/try-put! producer-chan ["1" resolve1])
       ;; Close the sink to make sure messages were sent
       (async/close! producer-chan)
+      ;; Allow the worker thread to consume all messages before aborting input
+      (Thread/sleep 500)
       (sink/stop! sink)
       ;; The promises were resolved
       (spy.assert/called-once-with? resolve0 "0" 0)

--- a/test/ketu/async/integration_test.clj
+++ b/test/ketu/async/integration_test.clj
@@ -120,8 +120,6 @@
       (u/try-put! producer-chan ["1" resolve1])
       ;; Close the sink to make sure messages were sent
       (async/close! producer-chan)
-      ;; Allow the worker thread to consume all messages before aborting input
-      (Thread/sleep 500)
       (sink/stop! sink)
       ;; The promises were resolved
       (spy.assert/called-once-with? resolve0 "0" 0)

--- a/test/ketu/async/sink_test.clj
+++ b/test/ketu/async/sink_test.clj
@@ -71,8 +71,6 @@
           sink (sink/sink ch opts)]
       (async/>!! ch "v")
       (async/close! ch)
-      ;; Allow the worker thread to consume all messages before aborting input
-      (Thread/sleep 500)
       (sink/stop! sink)
       (is (= [(producer/record "bundt" "v")] (.history producer))))))
 
@@ -241,7 +239,7 @@
                   :ketu.sink/producer-supplier (constantly producer)}
             ch (async/chan)
             sink (sink/sink ch opts)
-            throw! (fn ([& _] (throw (Exception. "test exception"))))]
+            throw! (fn [^Object _ ^long _] (throw (Exception. "test exception")))]
         (with-redefs [producer/close! throw!]
           (async/close! ch)
           (u/try-take! (sink/done-chan sink)))

--- a/test/ketu/async/sink_test.clj
+++ b/test/ketu/async/sink_test.clj
@@ -71,6 +71,8 @@
           sink (sink/sink ch opts)]
       (async/>!! ch "v")
       (async/close! ch)
+      ;; Allow the worker thread to consume all messages before aborting input
+      (Thread/sleep 500)
       (sink/stop! sink)
       (is (= [(producer/record "bundt" "v")] (.history producer))))))
 
@@ -192,7 +194,6 @@
           (sink/stop! sink)
           (is (= #{[:info "[sink=test] Start 1 worker(s)"]
                    [:info "[sink=test worker=0] Start"]
-                   [:info "[sink=test auto-close] Start"]
                    [:info "[sink=test worker=0] Exit"]
                    [:info "[sink=test auto-close] All workers are done"]
                    [:info "[sink=test] Close producer"]}


### PR DESCRIPTION
In this PR:

1. Removes the usage of go-loops to facilitate auto-shutdown of the producer sink, and removes one thread from the system.
2. Fixes a couple of race conditions in tests.