### PR TITLE
Avoid persisting auth token on workflow run

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Setup java
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Setup java
         uses: actions/setup-java@v2
         with:


### PR DESCRIPTION
From the checkout action readme:

> The auth token is persisted in the local git config. This enables your scripts to run authenticated git commands. The token is removed during post-job cleanup. Set persist-credentials: false to opt-out.

We do a simple checkout so there's no need to persist the token.